### PR TITLE
add optional permission boundary to roles

### DIFF
--- a/templates/cognito-user-pool.yaml
+++ b/templates/cognito-user-pool.yaml
@@ -11,6 +11,9 @@ Parameters:
     Type: String
   Environment:
     Type: String
+  PermissionBoundaryPolicyArn:
+    Description: ARN to the boundary policy used for roles
+    Type: String
 
 Resources:
 
@@ -41,29 +44,30 @@ Resources:
             - cognito-idp:CreateUserPool
             - cognito-idp:CreateUserPoolClient
             - cognito-idp:CreateUserPoolDomain
-            Resource: 
+            Resource:
             - '*'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
 
 
-  CreateUserPoolAndClientFunction: 
+  CreateUserPoolAndClientFunction:
     Type: AWS::Lambda::Function
-    Properties: 
+    Properties:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: python3.6
       Timeout: 60
-      Code: 
+      Code:
         ZipFile: |
           import boto3
           import cfnresponse
           def handler(event, context):
               responseData = {}
-              print (str(event)) 
-              try: 
+              print (str(event))
+              try:
                   if event['RequestType'] == 'Create':
                       Environment = event['ResourceProperties']['Environment']
-                      BaseUrl = event['ResourceProperties']['BaseUrl']                          
-                      client = boto3.client('cognito-idp') 
+                      BaseUrl = event['ResourceProperties']['BaseUrl']
+                      client = boto3.client('cognito-idp')
                       response = client.create_user_pool(
                           PoolName=Environment+'-userpool',
                           AutoVerifiedAttributes=['email'],
@@ -105,7 +109,7 @@ Resources:
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, "CustomResourcePhysicalID")
               except Exception as e:
                   responseData['Error'] = str(e)
-                  cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID") 
+                  cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID")
                   print("FAILED ERROR: " + responseData['Error'])
 
   CreateUserPoolAndClient:

--- a/templates/edge-auth.yaml
+++ b/templates/edge-auth.yaml
@@ -33,9 +33,12 @@ Parameters:
     Default: authorization-lambda-at-edge/
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: TemplatesPrefix key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).
+  PermissionBoundaryPolicyArn:
+    Description: ARN to a boundary policy if your organisation uses some for roles, optional
+    Type: String
+    Default: DefaultPermissionBoundaryPolicy
 
 Resources:
-
 
   CFOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -161,6 +164,17 @@ Resources:
                 Forward: none
             ViewerProtocolPolicy: redirect-to-https
 
+  DefaultPermissionBoundaryPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource: '*'
+      PolicyName: DefaultPermissionBoundaryPolicy
+
   CognitoUserPool:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -168,6 +182,7 @@ Resources:
       Parameters:
         BaseUrl:            !GetAtt CFDistribution.DomainName
         Environment:        !Ref AWS::StackName
+        PermissionBoundaryPolicyArn: !Ref PermissionBoundaryPolicyArn
 
   PopulateS3Buckets:
     Type: AWS::CloudFormation::Stack
@@ -184,6 +199,7 @@ Resources:
         PublicContentUrl:   !Sub 'http://${ArtifactsBucket}.s3.amazonaws.com/${ArtifactsPrefix}public.zip'
         PrivateContentUrl:  !Sub 'http://${ArtifactsBucket}.s3.amazonaws.com/${ArtifactsPrefix}private.zip'
         ConfigFile:         'js/config.js'
+        PermissionBoundaryPolicyArn: !Ref PermissionBoundaryPolicyArn
 
   LambdaAtEdge:
     Type: AWS::CloudFormation::Stack
@@ -194,6 +210,7 @@ Resources:
         PublicBucket:   !Ref S3BucketPublic
         PublicPrefix:   'lambda-at-edge/'
         EdgeAuthFunctionUrl:  !Sub 'http://${ArtifactsBucket}.s3.amazonaws.com/${ArtifactsPrefix}edge-auth.zip'
+        PermissionBoundaryPolicyArn: !Ref PermissionBoundaryPolicyArn
 
 
 Outputs:

--- a/templates/lambda-at-edge.yaml
+++ b/templates/lambda-at-edge.yaml
@@ -15,6 +15,9 @@ Parameters:
     Type: String
   EdgeAuthFunctionUrl:
     Type: String
+  PermissionBoundaryPolicyArn:
+    Description: ARN to the boundary policy used for roles
+    Type: String
 
 
 Resources:
@@ -47,18 +50,19 @@ Resources:
             Action:
             - s3:PutObject
             - s3:PutObjectAcl
-            Resource: 
+            Resource:
             - !Sub 'arn:aws:s3:::${PublicBucket}/*'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
 
-  UpdateConfigFunction: 
+  UpdateConfigFunction:
     Type: AWS::Lambda::Function
-    Properties: 
+    Properties:
       Handler: index.handler
       Role: !GetAtt UpdateConfigExecutionRole.Arn
       Runtime: python3.6
       Timeout: 60
       MemorySize: 1536
-      Code: 
+      Code:
         ZipFile: |
           import cfnresponse
           import os
@@ -71,13 +75,13 @@ Resources:
           def handler(event, context):
             print (str(event))
             responseData = {}
-            try: 
+            try:
               if (event['RequestType'] == 'Create') or (event['RequestType'] == 'Update'):
                   DestinationBucket = event['ResourceProperties']['DestinationBucket']
                   DestinationPrefix = event['ResourceProperties']['DestinationPrefix']
                   UserPoolId = event['ResourceProperties']['UserPoolId']
                   AWSRegion = event['ResourceProperties']['AWSRegion']
-                  SourceUrl = event['ResourceProperties']['SourceUrl']    
+                  SourceUrl = event['ResourceProperties']['SourceUrl']
                   print("get jwks value")
                   jwksUrl = 'https://cognito-idp.' + AWSRegion + '.amazonaws.com/' + UserPoolId + '/.well-known/jwks.json'
                   with urlopen(jwksUrl) as httpresponse:
@@ -112,7 +116,7 @@ Resources:
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, "CustomResourcePhysicalID")
             except Exception as e:
               responseData['Error'] = str(e)
-              cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID") 
+              cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID")
               print("FAILED ERROR: " + responseData['Error'])
           def addDirToZip(zipHandle, path, basePath=""):
               basePath = basePath.rstrip("\\/") + ""
@@ -166,28 +170,24 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
 
 
-  EdgeAuthFunction: 
+  EdgeAuthFunction:
     Type: AWS::Lambda::Function
     DependsOn: UpdateConfigCustom
     DeletionPolicy: Retain
-    Properties: 
+    Properties:
       Handler: index.handler
       Role: !GetAtt EdgeAuthExecutionRole.Arn
       Runtime: nodejs10.x
       Timeout: 1
       MemorySize: 128
       Code:
-        S3Bucket: !Ref PublicBucket 
+        S3Bucket: !Ref PublicBucket
         S3Key: !Sub ${PublicPrefix}edge-auth.zip
 
 Outputs:
-  EdgeAuthFunction: 
+  EdgeAuthFunction:
     Description: Reference to the Lambda function
     Value: !Ref EdgeAuthFunction
-
-
-
-
-

--- a/templates/populate-s3-bucket.yaml
+++ b/templates/populate-s3-bucket.yaml
@@ -28,6 +28,9 @@ Parameters:
     Type: String
   ConfigFile:
     Type: String
+  PermissionBoundaryPolicyArn:
+    Description: ARN to the boundary policy used for roles
+    Type: String
 
 Resources:
 
@@ -61,16 +64,17 @@ Resources:
             Resource:
             - !Sub 'arn:aws:s3:::${PublicBucket}/*'
             - !Sub 'arn:aws:s3:::${PrivateBucket}/*'
-            
-  PopulateS3BucketFunction: 
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+
+  PopulateS3BucketFunction:
     Type: AWS::Lambda::Function
-    Properties: 
+    Properties:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: python3.6
       Timeout: 60
       MemorySize: 1536
-      Code: 
+      Code:
         ZipFile: |
           from io import BytesIO
           from urllib.request import urlopen
@@ -83,7 +87,7 @@ Resources:
             print (str(event))
             responseData = {}
             contenttype = {'html': 'text/html', 'js': 'application/javascript', 'css': 'text/css', 'json':'application/json'}
-            try: 
+            try:
               SourceUrl = event['ResourceProperties']['SourceUrl']
               DestinationBucket = event['ResourceProperties']['DestinationBucket']
               DestinationPrefix = event['ResourceProperties']['DestinationPrefix']
@@ -106,9 +110,9 @@ Resources:
               print ('SUCCESS')
             except Exception as e:
               responseData['Error'] = str(e)
-              cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID") 
+              cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID")
               print("FAILED ERROR: " + responseData['Error'])
- 
+
 
   PopulatePublicBucket:
     Type: Custom::PopulatePublicBucket
@@ -126,15 +130,15 @@ Resources:
       DestinationPrefix: !Ref PrivatePrefix
       SourceUrl: !Ref PrivateContentUrl
 
-  WriteConfigFileFunction: 
+  WriteConfigFileFunction:
     Type: AWS::Lambda::Function
-    Properties: 
+    Properties:
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: python3.6
       Timeout: 30
       MemorySize: 1536
-      Code: 
+      Code:
         ZipFile: |
           from io import BytesIO
           from urllib.request import urlopen
@@ -146,19 +150,19 @@ Resources:
           def handler(event, context):
             responseData = {}
             print (str(event))
-            try: 
+            try:
               DestinationBucket = event['ResourceProperties']['DestinationBucket']
               DestinationPrefix = event['ResourceProperties']['DestinationPrefix']
               UserPoolId = event['ResourceProperties']['UserPoolId']
               ClientId = event['ResourceProperties']['ClientId']
               AWSRegion = event['ResourceProperties']['AWSRegion']
               BaseUrl = event['ResourceProperties']['BaseUrl']
-              ConfigFile = event['ResourceProperties']['ConfigFile']              
+              ConfigFile = event['ResourceProperties']['ConfigFile']
               config = ""
               config = config + "var UserPoolId = '" + UserPoolId + "';\n"
               config = config + "var ClientId = '" + ClientId + "';\n"
-              config = config + "var AWSRegion = '" + AWSRegion + "';\n"  
-              config = config + "var BaseUrl = '" + BaseUrl + "';\n" 
+              config = config + "var AWSRegion = '" + AWSRegion + "';\n"
+              config = config + "var BaseUrl = '" + BaseUrl + "';\n"
               print(config)
               s3 = boto3.client('s3')
               s3.put_object(Body=config, Bucket=DestinationBucket, Key=DestinationPrefix + ConfigFile, ContentType='application/javascript')
@@ -167,7 +171,7 @@ Resources:
             except Exception as e:
               responseData['Error'] = str(e)
               cfnresponse.send(event, context, cfnresponse.FAILED, responseData, "CustomResourcePhysicalID")
-              print("FAILED ERROR: " + responseData['Error']) 
+              print("FAILED ERROR: " + responseData['Error'])
 
   WriteConfigFile:
     Type: Custom::WriteConfigFile
@@ -180,8 +184,4 @@ Resources:
       UserPoolId: !Ref UserPoolId
       ClientId: !Ref ClientId
       BaseUrl: !Ref BaseUrl
-      ConfigFile: !Ref ConfigFile 
-
-
-
-
+      ConfigFile: !Ref ConfigFile


### PR DESCRIPTION
- [x] add an optional `PermissionBoundaryPolicyArn` as variable, to be used as a boundary policy ARN for the organisations that need it
- [x] saved privately in Centrica prod OTP account's [serverless application repository](https://serverlessrepo.aws.amazon.com/applications) for now
